### PR TITLE
Android MemoryCache is recreated every time

### DIFF
--- a/source/FFImageLoading.Maui/Platforms/Android/Foundations/ImageService.cs
+++ b/source/FFImageLoading.Maui/Platforms/Android/Foundations/ImageService.cs
@@ -35,7 +35,7 @@ namespace FFImageLoading
 
 		ImageCache imageCache;
 
-		public override IMemoryCache<SelfDisposingBitmapDrawable> MemoryCache => imageCache ?? new ImageCache(Configuration, Logger);
+		public override IMemoryCache<SelfDisposingBitmapDrawable> MemoryCache => imageCache ??= new ImageCache(Configuration, Logger);
 
 
         public override IImageLoaderTask CreateTask<TImageView>(TaskParameter parameters, ITarget<SelfDisposingBitmapDrawable, TImageView> target) where TImageView : class


### PR DESCRIPTION
MemoryCache doesn't work on Android because it's recreated every time