### PR TITLE
Fix AspectFill images with an implicit height

### DIFF
--- a/source/FFImageLoading.Maui/Platforms/Android/CachedImageHandler.cs
+++ b/source/FFImageLoading.Maui/Platforms/Android/CachedImageHandler.cs
@@ -95,30 +95,42 @@ namespace FFImageLoading.Maui.Platform
 			}
 		}
 
-
 		private void UpdateAspect()
-        {
-            if (PlatformView == null || PlatformView.Handle == IntPtr.Zero || VirtualView == null || _isDisposed)
-                return;
+		{
+			if (PlatformView == null || PlatformView.Handle == IntPtr.Zero || VirtualView == null || _isDisposed)
+				return;
 
-            if (VirtualView.Aspect == Aspect.AspectFill)
+			if (VirtualView.Aspect == Aspect.AspectFill)
 			{
 				PlatformView.SetScaleType(ImageView.ScaleType.CenterCrop);
-				if ((int)Build.VERSION.SdkInt >= 18)
-				{
-					var density = DeviceDisplay.Current.MainDisplayInfo.Density;
-					PlatformView.ClipBounds = new Android.Graphics.Rect(0, 0, (int)(VirtualView.WidthRequest * density), (int)(VirtualView.HeightRequest * density));
-				}
-			} 
+			}
 
-            else if (VirtualView.Aspect == Aspect.Fill)
+			else if (VirtualView.Aspect == Aspect.Fill)
 				PlatformView.SetScaleType(ImageView.ScaleType.FitXy);
 
-            else
+			else
 				PlatformView.SetScaleType(ImageView.ScaleType.FitCenter);
-        }
+		}
 
-        private void UpdateBitmap(CachedImageView imageView, CachedImage image, CachedImage previousImage)
+		public override void PlatformArrange(Microsoft.Maui.Graphics.Rect frame)
+		{
+			if (PlatformView == null || PlatformView.Handle == IntPtr.Zero || VirtualView == null || _isDisposed)
+				return;
+
+			if (VirtualView.Aspect == Aspect.AspectFill)
+			{
+				if ((int)Build.VERSION.SdkInt >= 18)
+				{
+					var (left, top, right, bottom) = PlatformView.Context!.ToPixels(VirtualView.Frame);
+					var clipRect = new Android.Graphics.Rect(0, 0, right - left, bottom - top);
+					PlatformView.ClipBounds = clipRect;
+				}
+			}
+
+			base.PlatformArrange(frame);
+		}
+
+		private void UpdateBitmap(CachedImageView imageView, CachedImage image, CachedImage previousImage)
         {
             lock (_updateBitmapLock)
             {


### PR DESCRIPTION
## The issue

Fix the bug in `1.0.7` in which `AspectFill` does not work for images whose dimensions are set implicitly (e.g. by a grid with a fixed width and height). See [this discussion](https://github.com/microspaze/FFImageLoading.Maui/issues/13#issuecomment-1927554744) for more information.

## The fix

Clip images as done in the [MAUI source](https://github.com/dotnet/maui/blob/main/src/Core/src/Handlers/Image/ImageHandler.Android.cs) so that explicit sizes (set by `HeightRequest` and `WidthRequest` work as well as implicit dimensions set via something like a grid. See  for more information.

## Testing

You can test by copy/pasting this code into one of the `Sample` project's pages:

```
<!--Grid broken by 1.0.7-->
 <Label
            Text="Grid broken by 1.0.7 due to implicit height/width"
            SemanticProperties.HeadingLevel="Level2"
            FontSize="18"
            HorizontalOptions="Center" />

<Grid ColumnDefinitions="130" RowDefinitions="130, 130">
  <ffimageloading:CachedImage Source="maui_beach_wikimedia.png"
      Aspect="AspectFill" IsVisible="true"
      AutomationProperties.IsInAccessibleTree="False"></ffimageloading:CachedImage>
  <Image Source="maui_beach_wikimedia.png" Grid.Row="1"
      Aspect="AspectFill" IsVisible="true"
      AutomationProperties.IsInAccessibleTree="False">
   </Image>
</Grid>

<!--Grid fixed by 1.0.7-->
<Label
           Text="Grid fixed by 1.0.7 with explicit height/width"
           SemanticProperties.HeadingLevel="Level2"
           FontSize="18"
           HorizontalOptions="Center" />

<Grid ColumnDefinitions="130" RowDefinitions="130, 130">
  <ffimageloading:CachedImage Source="maui_beach_wikimedia.png" HeightRequest="130" WidthRequest="130"
                                                       Aspect="AspectFill" IsVisible="true"  AutomationProperties.IsInAccessibleTree="False">. 
  </ffimageloading:CachedImage>
  <Image Source="maui_beach_wikimedia.png" HeightRequest="130" WidthRequest="130" Grid.Row="1"
                Aspect="AspectFill" IsVisible="true"
                AutomationProperties.IsInAccessibleTree="False">
  </Image> 
</Grid>
```