### PR TITLE
Handling window closed exception.

### DIFF
--- a/source/FFImageLoading.Maui/Platforms/Windows/CachedImageHandler.cs
+++ b/source/FFImageLoading.Maui/Platforms/Windows/CachedImageHandler.cs
@@ -106,9 +106,19 @@ namespace FFImageLoading.Maui.Platform
             if (image == null || imageView == null || _isDisposed)
                 return;
 
-			var scale = VirtualView?.GetVisualElementWindow()?.RequestDisplayDensity()
+            double scale;
+            
+            try
+            {
+                scale = VirtualView?.GetVisualElementWindow()?.RequestDisplayDensity()
 					?? (float)DeviceDisplay.MainDisplayInfo.Density;
-
+            } 
+            catch (InvalidOperationException ex) 
+            {
+                // This can happen if the window has been closed. We can avoid propagating the exception for the main application.
+                return;
+            }
+			 
 			var ffSource = await ImageSourceBinding.GetImageSourceBinding(image.Source, image).ConfigureAwait(false);
             if (ffSource == null)
             {


### PR DESCRIPTION
The problem has been described in here:
https://github.com/microspaze/FFImageLoading.Maui/issues/44

Unfortunately, there isn't another way else then catching an exception. I tried to check for a property that indicated that the window was closed or something like that. But, it doesn't really works.