### PR TITLE
Prevent DI Configuration HttpClient from being overwritten on init

### DIFF
--- a/source/FFImageLoading.Maui/Foundations/ImageServiceBase.cs
+++ b/source/FFImageLoading.Maui/Foundations/ImageServiceBase.cs
@@ -64,7 +64,7 @@ namespace FFImageLoading
         {
             get
             {
-                InitializeIfNeeded();
+                InitializeIfNeeded(_config);
                 return _config;
             }
         }
@@ -81,7 +81,7 @@ namespace FFImageLoading
             lock (_initializeLock)
             {
                 _initialized = false;
-                InitializeIfNeeded();
+                InitializeIfNeeded(_config);
             }
         }
 


### PR DESCRIPTION
This change makes sure the Configuration is used that is supplied during DI. 

At the moment the `Configuration.HttpClient` is being overwritten because `ImageServiceBase.InitializeIfNeeded` will always at least run once. The line below will always override the implementation done via DI since `userDefinedConfig` will always be null when it's initialized the first time.

https://github.com/microspaze/FFImageLoading.Maui/blob/408bdb6d6d1cdd81f4f536b1a6509ff45618d01a/source/FFImageLoading.Maui/Foundations/ImageServiceBase.cs#L124

```cs
var ffilConfig = new FFImageLoading.Config.Configuration()
{
AllowUpscale = true,
DiskCacheDuration = TimeSpan.FromDays(AppData.CACHE_DURATION),
DiskCachePath = CreateDiskCachePath(),
HttpClient = new HttpClient(new AuthenticatedHttpImageClientHandler(SessionManagerStatic.GetAccessTokenAsync)),
HttpHeadersTimeout = HttpSettings.HttpHeadersTimeoutForImages,
HttpReadTimeout = HttpSettings.HttpReadTimeoutForImages
};
builder.Services.AddSingleton<FFImageLoading.Config.IConfiguration>(ffilConfig);
```

This should be the preferred way to configure FFImageLoading but at the moment it doesn't work because of the above issue.