### PR TITLE
Fixed Windows PlatformView null crash

### DIFF
--- a/source/FFImageLoading.Maui/Platforms/Windows/CachedImageHandler.cs
+++ b/source/FFImageLoading.Maui/Platforms/Windows/CachedImageHandler.cs
@@ -214,7 +214,7 @@ namespace FFImageLoading.Maui.Platform
 					return;
 				
 				// Wonky situation where you need the parent to remeasure to affect the actual image control
-				(PlatformView?.Parent as FrameworkElement)?.InvalidateMeasure();
+				(((ViewHandler)this).PlatformView?.Parent as FrameworkElement)?.InvalidateMeasure();
 
 				if (!isLoading)
 					element.SetIsLoading(isLoading);


### PR DESCRIPTION
fixes #75

MAUI's `ViewHandler<TVirtualView, TPlatformView>.PlatformView` has a null check that throws an exception. Going down a layer to the `ViewHandler` since there is already a null check in place here. I noticed several other places that the same thing is being done. Those null check are going to do nothing since an exception is thrown.